### PR TITLE
✨ Feat: #18 Shazam 검색 결과 내 뮤직 리스트 추가 기능 및 UI 버그 수정

### DIFF
--- a/Headliner/Headliner/Source/Presentation/Home/HomeView.swift
+++ b/Headliner/Headliner/Source/Presentation/Home/HomeView.swift
@@ -78,6 +78,7 @@ struct HomeView: View {
                 }
             }
         }
+        .environmentObject(viewModel)
     }
 }
 

--- a/Headliner/Headliner/Source/Presentation/Main/MainListView.swift
+++ b/Headliner/Headliner/Source/Presentation/Main/MainListView.swift
@@ -8,11 +8,6 @@
 import SwiftUI
 
 struct MainListView: View {
-    // TODO: 실제 데이터 연결 필요
-//    let dummy: [Music] = (0..<10).map { i in
-//        Music(id: "\(i)", title: "어제보다 슬픈 오늘", artistName: "마크툽",
-//              artworkURL: nil, previewURL: nil)
-//    }
     
     let playList: [PlaylistMusic]
     

--- a/Headliner/Headliner/Source/Presentation/Main/MusicRowView.swift
+++ b/Headliner/Headliner/Source/Presentation/Main/MusicRowView.swift
@@ -14,9 +14,7 @@ struct MusicRowView: View {
     let previewURL: URL?
 
     var body: some View {
-        ZStack {
-            Color.clear
-            
+        ZStack { 
             HStack(spacing: 20) {
                 AsyncImage(url: artworkURL) { phase in
                 switch phase {

--- a/Headliner/Headliner/Source/Presentation/Shazam/MediaItemView.swift
+++ b/Headliner/Headliner/Source/Presentation/Shazam/MediaItemView.swift
@@ -9,8 +9,9 @@ import SwiftUI
 import ShazamKit
 
 struct MediaItemView: View {
-    let mediaItem: SHMediaItem
     @EnvironmentObject var pathModel: PathModel
+    @EnvironmentObject var shazamVM: ShazamViewModel
+    let mediaItem: SHMediaItem
 
     var body: some View {
         ZStack {
@@ -29,7 +30,10 @@ struct MediaItemView: View {
                 
                 HStack {
                     Button {
-                        
+                        Task {
+                            let music = mediaItem.toMusic()
+                            await shazamVM.addMusic(song: music)
+                        }
                     } label: {
                         Text("추가하기")
                     }
@@ -67,20 +71,14 @@ struct MediaItemView: View {
     }
 }
 
-#Preview {
-    let item = SHMediaItem(properties: [
-        .title: "어제보다 슬픈 오늘",
-        .artist: "마크툽",
-        .artworkURL: URL(string: "https://picsum.photos/512")!
-    ])
-
-    return ZStack {
-        LinearGradient(colors: [Color(red: 0.08, green: 0.10, blue: 0.18),
-                                Color(red: 0.03, green: 0.02, blue: 0.06)],
-                       startPoint: .top, endPoint: .bottom)
-            .ignoresSafeArea()
-        MediaItemView(mediaItem: item)
-            .padding(.vertical, 24)
+extension SHMediaItem {
+    func toMusic() -> Music {
+        Music(
+            id: self.shazamID ?? UUID().uuidString,
+            title: self.title ?? "제목 없음",
+            artistName: self.artist ?? "아티스트 없음",
+            artworkURL: self.artworkURL,   // nil일 수 있음
+            previewURL: nil   // nil일 수 있음
+        )
     }
-    .preferredColorScheme(.dark)
 }

--- a/Headliner/Headliner/Source/Presentation/Shazam/ShazamViewModel.swift
+++ b/Headliner/Headliner/Source/Presentation/Shazam/ShazamViewModel.swift
@@ -24,8 +24,9 @@ final class ShazamViewModel: ObservableObject {
     
     @Published var query: String = ""
     @Published var results: [Music] = []
-    @Published var playList: [PlaylistMusic] = []
-
+    @Published private(set) var playList: [PlaylistMusic] = []
+    private var playListIDs = Set<String>()   // song.id 모음
+    
     var title: String { currentItem?.title ?? "" }
     var artist: String { currentItem?.artist ?? "" }
     var artworkURL: URL? { currentItem?.artworkURL }
@@ -35,53 +36,53 @@ final class ShazamViewModel: ObservableObject {
     
     private var cancellables = Set<AnyCancellable>()
     private let service: MusicServicing
-
+    
     private let managedSession = SHManagedSession()
     private let library = SHLibrary.default
-
+    
     init(service: MusicServicing = MusicManager()) {
         self.service = service
         bindSearchTerm()
-
-
+        
+        
         Task { _ = await service.requestAuthorization() }
     }
-
+    
     func prepare() async {
         await managedSession.prepare()
     }
-
+    
     func start() {
         guard isListening == false else { return }
         isListening = true
         currentItem = nil
         errorDescription = nil
         self.status = .loading
-
+        
         Task { [weak self] in
             guard let self else { return }
             let result = await self.managedSession.result()
             await self.handle(result)
         }
     }
-
+    
     func retry() { start() }
-
+    
     func cancel() {
         managedSession.cancel()
         isListening = false
         status = .search
     }
-
+    
     private func handle(_ result: SHSession.Result) async {
         managedSession.cancel()
         isListening = false
-
+        
         switch result {
         case .match(let match):
             if let item = match.mediaItems.first {
                 currentItem = item
-                    status = .completed
+                status = .completed
             } else {
                 currentItem = nil
             }
@@ -98,18 +99,18 @@ final class ShazamViewModel: ObservableObject {
             .debounce(for: .milliseconds(500), scheduler: RunLoop.main)
             .removeDuplicates()
             .sink { [weak self] term in
-            DispatchQueue.main.async {
-                guard let self = self else { return }
-
-                if term.count >= 2 {
-                    Task {
-                        await self.search(with: self.query)
+                DispatchQueue.main.async {
+                    guard let self = self else { return }
+                    
+                    if term.count >= 2 {
+                        Task {
+                            await self.search(with: self.query)
+                        }
+                    } else {
+                        //                    self.results = []
                     }
-                } else {
-//                    self.results = []
                 }
             }
-        }
             .store(in: &cancellables)
     }
     
@@ -126,24 +127,25 @@ final class ShazamViewModel: ObservableObject {
                 
                 results = searchResults
             } catch {
-//                results = []
+                //                results = []
             }
         }
     }
     
-    func addMusic(song: Music) async {
-        await MainActor.run {
-            let newPlaylistSong = PlaylistMusic(
-                id: song.id,
-                originalSong: song,
-                karaokeNumber: "000000"
-            )
-            
-            self.playList.append(newPlaylistSong)
-            
-            print("Playlist에 추가됨: \(newPlaylistSong.originalSong.title) - 노래방 번호: \(newPlaylistSong.karaokeNumber ?? "없음")")
-            print("PlayList: \(playList)")
-        }
+    @MainActor
+    func addMusic(song: Music) {
+        guard playListIDs.insert(song.id).inserted else { return } // 이미 있으면 종료
+        let newPlaylistSong = PlaylistMusic(
+            id: song.id,
+            originalSong: song,
+            karaokeNumber: "000000"
+        )
+        
+        self.playList.append(newPlaylistSong)
+
+        
+        print("Playlist에 추가됨: \(newPlaylistSong.originalSong.title) - 노래방 번호: \(newPlaylistSong.karaokeNumber ?? "없음")")
+        print("PlayList: \(playList)")
     }
     
     @MainActor


### PR DESCRIPTION
✨ What’s this PR?
   - Shazam으로 인식한 음악을 사용자의 내 뮤직 리스트에 저장할 수 있는 기능 구현
   - 추가 시 2번째 곡부터 잘못 표시되던 UI 버그를 수정
---
📌 관련 이슈
   - Closes #18 
---
🧶 주요 변경 내용 (Summary)
   - Shazam → Music 변환 로직 추가
       - SHMediaItem을 앱의 Music 모델로 변환하는 toMusic extension 구현
   - 상태 관리 개선
       - ShazamViewModel을 HomeView에서 EnvironmentObject로 주입해 하위 뷰와 상태 공유
   - 추가 기능 구현
       - ‘추가하기’ 버튼 클릭 시 변환된 곡을 내 뮤직 리스트에 반영
   - UI 버그 수정
       - 2번째 곡부터 최하단에 잘못 표시되던 문제 해결