### PR TITLE
♻️ Refactor: #20 ShazamSearchView 로직 분리 및 KaraokeAPI 연동

### DIFF
--- a/Headliner/Headliner/Source/Model/Music.swift
+++ b/Headliner/Headliner/Source/Model/Music.swift
@@ -13,5 +13,5 @@ struct Music: Identifiable, Hashable {
     let artistName: String
     let artworkURL: URL?
     let previewURL: URL? // 미리듣기 URL
-    let karaokeNumber: String = ""
+    
 }

--- a/Headliner/Headliner/Source/Presentation/General/Path.swift
+++ b/Headliner/Headliner/Source/Presentation/General/Path.swift
@@ -6,6 +6,14 @@
 //
 
 import Foundation
+import ShazamKit
+
+struct MediaRoute: Hashable {
+    let title: String
+    let artist: String
+    let artworkURL: URL?
+    let mediaItem: SHMediaItem?
+}
 
 enum PathType: Hashable {
     case loading

--- a/Headliner/Headliner/Source/Presentation/Main/MainListView.swift
+++ b/Headliner/Headliner/Source/Presentation/Main/MainListView.swift
@@ -71,7 +71,8 @@ struct MainListView: View {
                     MusicRowView(title: t.originalSong.title,
                                  artistName: t.originalSong.artistName,
                                  artworkURL: t.originalSong.artworkURL,
-                                 previewURL: t.originalSong.previewURL)
+                                 previewURL: t.originalSong.previewURL,
+                                 karaokeNumber: "12345")
                 }
             }
         }
@@ -99,6 +100,5 @@ private struct EmptyPlaylistView: View {
         }
         .padding(.horizontal, 24)
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        // 배경 그라디언트는 상위에서 이미 깔려 있음
     }
 }

--- a/Headliner/Headliner/Source/Presentation/Main/MainListView.swift
+++ b/Headliner/Headliner/Source/Presentation/Main/MainListView.swift
@@ -72,7 +72,7 @@ struct MainListView: View {
                                  artistName: t.originalSong.artistName,
                                  artworkURL: t.originalSong.artworkURL,
                                  previewURL: t.originalSong.previewURL,
-                                 karaokeNumber: "12345")
+                                 karaokeNumber: t.karaokeNumber)
                 }
             }
         }

--- a/Headliner/Headliner/Source/Presentation/Main/MusicRowView.swift
+++ b/Headliner/Headliner/Source/Presentation/Main/MusicRowView.swift
@@ -12,6 +12,7 @@ struct MusicRowView: View {
     let artistName: String
     let artworkURL: URL?
     let previewURL: URL?
+    let karaokeNumber: String?
 
     var body: some View {
         ZStack { 
@@ -43,9 +44,11 @@ struct MusicRowView: View {
                             
                         }
                         Spacer()
-                        Text("12345")
-                            .font(.pretendardSemiBold16)
-                            .foregroundStyle(.white.opacity(0.6))
+                        if let karaokeNumber {
+                            Text(karaokeNumber)
+                                .font(.pretendardSemiBold16)
+                                .foregroundStyle(.white.opacity(0.6))
+                        }
                     }
                     .padding(.vertical, 10)
                     Divider()

--- a/Headliner/Headliner/Source/Presentation/Shazam/MediaItemView.swift
+++ b/Headliner/Headliner/Source/Presentation/Shazam/MediaItemView.swift
@@ -77,8 +77,8 @@ extension SHMediaItem {
             id: self.shazamID ?? UUID().uuidString,
             title: self.title ?? "제목 없음",
             artistName: self.artist ?? "아티스트 없음",
-            artworkURL: self.artworkURL,   // nil일 수 있음
-            previewURL: nil   // nil일 수 있음
+            artworkURL: self.artworkURL,
+            previewURL: nil
         )
     }
 }

--- a/Headliner/Headliner/Source/Presentation/Shazam/ShazamSearchView.swift
+++ b/Headliner/Headliner/Source/Presentation/Shazam/ShazamSearchView.swift
@@ -30,12 +30,30 @@ struct ShazamSearchView: View {
                     ScrollView {
                         LazyVStack(spacing: 0) {
                             ForEach(viewModel.results) { song in
-                                MusicRowView(
-                                    title: song.title,
-                                    artistName: song.artistName,
-                                    artworkURL: song.artworkURL,
-                                    previewURL: song.previewURL
-                                )
+                                Button {
+                                    let properties: [SHMediaItemProperty: Any] = [
+                                        .title: song.title,
+                                        .artist: song.artistName,
+                                        .artworkURL: song.artworkURL as Any
+                                    ]
+                                    let mediaItem = SHMediaItem(properties: properties)
+                                    
+                                    let route = MediaRoute(
+                                        title: song.title,
+                                        artist: song.artistName,
+                                        artworkURL: song.artworkURL,
+                                        mediaItem: mediaItem
+                                    )
+                                    pathModel.paths.append(.result(route))
+                                } label: {
+                                    MusicRowView(
+                                        title: song.title,
+                                        artistName: song.artistName,
+                                        artworkURL: song.artworkURL,
+                                        previewURL: song.previewURL,
+                                        karaokeNumber: nil
+                                    )
+                                }
                             }
                         }
                     }
@@ -122,3 +140,4 @@ struct SearchBarView: View {
         .padding(.vertical, 12)
     }
 }
+

--- a/Headliner/Headliner/Source/Presentation/Shazam/ShazamSearchView.swift
+++ b/Headliner/Headliner/Source/Presentation/Shazam/ShazamSearchView.swift
@@ -2,12 +2,7 @@ import SwiftUI
 import ShazamKit
 import MusicKit
 
-struct MediaRoute: Hashable {
-    let title: String
-    let artist: String
-    let artworkURL: URL?
-    let mediaItem: SHMediaItem?
-}
+
 
 struct ShazamSearchView: View {
     @EnvironmentObject var pathModel: PathModel
@@ -31,20 +26,7 @@ struct ShazamSearchView: View {
                         LazyVStack(spacing: 0) {
                             ForEach(viewModel.results) { song in
                                 Button {
-                                    let properties: [SHMediaItemProperty: Any] = [
-                                        .title: song.title,
-                                        .artist: song.artistName,
-                                        .artworkURL: song.artworkURL as Any
-                                    ]
-                                    let mediaItem = SHMediaItem(properties: properties)
-                                    
-                                    let route = MediaRoute(
-                                        title: song.title,
-                                        artist: song.artistName,
-                                        artworkURL: song.artworkURL,
-                                        mediaItem: mediaItem
-                                    )
-                                    pathModel.paths.append(.result(route))
+                                    viewModel.handleMusicSelection(song: song)
                                 } label: {
                                     MusicRowView(
                                         title: song.title,
@@ -77,15 +59,9 @@ struct ShazamSearchView: View {
         .task {
             await viewModel.prepare()
         }
-        .onChange(of: viewModel.currentItem) { _, item in
-            if let item {
-                let route = MediaRoute(
-                    title: item.title ?? "",
-                    artist: item.artist ?? "",
-                    artworkURL: item.artworkURL,
-                    mediaItem: item
-                )
-                pathModel.paths.append(.result(route))
+        .onChange(of: viewModel.navigationRoute) { _, route in
+            if let route = route {
+                pathModel.paths.append(route)
             }
         }
     }
@@ -94,7 +70,6 @@ struct ShazamSearchView: View {
         Button{
             if !viewModel.isListening {
                 viewModel.start()
-                pathModel.paths.append(.loading)
             }
         } label: {
             Image(.shazamButton)

--- a/Headliner/Headliner/Source/Presentation/Shazam/ShazamViewModel.swift
+++ b/Headliner/Headliner/Source/Presentation/Shazam/ShazamViewModel.swift
@@ -21,6 +21,7 @@ final class ShazamViewModel: ObservableObject {
     @Published var currentItem: SHMediaItem?
     @Published var errorDescription: String?
     @Published var status: Status = .search
+    @Published var navigationRoute: PathType?
     
     @Published var query: String = ""
     @Published var results: [Music] = []
@@ -58,6 +59,7 @@ final class ShazamViewModel: ObservableObject {
         currentItem = nil
         errorDescription = nil
         self.status = .loading
+        self.navigationRoute = .loading
         
         Task { [weak self] in
             guard let self else { return }
@@ -83,6 +85,14 @@ final class ShazamViewModel: ObservableObject {
             if let item = match.mediaItems.first {
                 currentItem = item
                 status = .completed
+                
+                let route = MediaRoute(
+                    title: item.title ?? "",
+                    artist: item.artist ?? "",
+                    artworkURL: item.artworkURL,
+                    mediaItem: item
+                )
+                self.navigationRoute = .result(route)
             } else {
                 currentItem = nil
             }
@@ -92,6 +102,23 @@ final class ShazamViewModel: ObservableObject {
             errorDescription = error.localizedDescription
             currentItem = nil
         }
+    }
+    
+    func handleMusicSelection(song: Music) {
+        let properties: [SHMediaItemProperty: Any] = [
+            .title: song.title,
+            .artist: song.artistName,
+            .artworkURL: song.artworkURL as Any
+        ]
+        let mediaItem = SHMediaItem(properties: properties)
+        
+        let route = MediaRoute(
+            title: song.title,
+            artist: song.artistName,
+            artworkURL: song.artworkURL,
+            mediaItem: mediaItem
+        )
+        self.navigationRoute = .result(route)
     }
     
     private func bindSearchTerm() {
@@ -133,16 +160,28 @@ final class ShazamViewModel: ObservableObject {
     }
     
     @MainActor
-    func addMusic(song: Music) {
-        guard playListIDs.insert(song.id).inserted else { return } // 이미 있으면 종료
+    func addMusic(song: Music) async { 
+        guard playListIDs.insert(song.id).inserted else { return }
+        
+        var fetchedKaraokeNumber: String? = nil
+        
+        await getKaraokeNumber(
+            title: song.title,
+            singer: song.artistName,
+            brand: "tj", // 기본 브랜드 "tj" 사용
+            limit: "1",  // 첫 번째 결과만 가져옴
+            page: "1"
+        )
+        fetchedKaraokeNumber = self.karaokeResponse?.data?.first?.no
+        
         let newPlaylistSong = PlaylistMusic(
             id: song.id,
             originalSong: song,
-            karaokeNumber: "000000"
+            karaokeNumber: fetchedKaraokeNumber ?? "없음"
         )
         
         self.playList.append(newPlaylistSong)
-
+        
         
         print("Playlist에 추가됨: \(newPlaylistSong.originalSong.title) - 노래방 번호: \(newPlaylistSong.karaokeNumber ?? "없음")")
         print("PlayList: \(playList)")


### PR DESCRIPTION
✨ What’s this PR?
   - ShazamSearchView의 검색/선택 관련 로직을 ViewModel로 분리하여 구조 개선
   - 검색 결과를 KaraokeAPI에 전달해 노래방 번호를 조회하는 기능을 추가
---
📌 관련 이슈
   - Closes #20 
 ---
🧶 주요 변경 내용 (Summary)
   - 로직 분리
     - ShazamSearchView 내부 로직을 ShazamSearchViewModel로 이전
     - View는 UI 표현과 상태 바인딩만 담당하도록 구조 단순화
   - KaraokeAPI 연동
     - 검색 결과를 API에 전달해 노래방 번호를 받아오도록 구현
     - SHMediaItem → API 요청 데이터 매핑 로직 추가