### PR TITLE
🐛 Fix. Shazam 비동기 처리 및 재시도 버튼 로직 개선

### DIFF
--- a/Headliner/Headliner/Source/Managers/ShazamManager.swift
+++ b/Headliner/Headliner/Source/Managers/ShazamManager.swift
@@ -6,11 +6,12 @@
 //
 
 import ShazamKit
+import AVFoundation
 
 protocol ShazamManagerType {
     func getListeningStatus() -> Bool
     func prepare() async
-    func startShazam() -> MusicSearchResult?
+    func startShazam() async -> MusicSearchResult?
     func isPossibleShazam() -> Bool?
     func cancel() -> ShazamStatus
 }
@@ -31,15 +32,6 @@ extension ShazamManager {
         await shManagedSession.prepare()
     }
     
-//    func start() {
-//        startShazam()
-//    }
-    
-//    func startShazamForRetry() {
-//        startShazam(shouldTriggerNavigation: false)
-//    }
-    
-    
     func isPossibleShazam() -> Bool? {
         guard isListening == false else { return false }
         isListening = true
@@ -47,40 +39,25 @@ extension ShazamManager {
         return true
     }
     
-    func startShazam() -> MusicSearchResult? {
-        print("ShazamManager startShazam")
-        
-//        currentItem = nil
-//        errorDescription = nil
+    func startShazam() async -> MusicSearchResult? {
+
         status = .loading
         
-        var handledResult: MusicSearchResult? = nil
+        let result = await self.shManagedSession.result()
+        let matchedItem = await self.handle(result)
         
-//        if shouldTriggerNavigation {
-//            container.pathModel.append(.loading)
-//            pathModel.append(.loading)
-//        }
         
-        Task { [weak self] in
-            guard let self else { return }
-            let result = await self.shManagedSession.result()
-            
-            let item = await self.handle(result)
-            handledResult = MusicSearchResult(
-                title: item?.title ?? "",
-                artist: item?.artist ?? "",
-                artworkURL: item?.artworkURL,
-                mediaItem: item,
-                showsRetryButton: true
-            )
-        }
+        let searchResult = MusicSearchResult(
+            title: matchedItem?.title ?? "결과 없음",
+            artist: matchedItem?.artist ?? "",
+            artworkURL: matchedItem?.artworkURL,
+            mediaItem: matchedItem,
+            showsRetryButton: matchedItem == nil
+        )
         
-        return handledResult
+        return searchResult
     }
     
-//    func retry() {
-//        startShazam()
-//    }
     
     func cancel() -> ShazamStatus {
         shManagedSession.cancel()
@@ -92,37 +69,21 @@ extension ShazamManager {
     
     /// Shazam 검색 성공 시 결과 return
     private func handle(_ result: SHSession.Result) async -> SHMatchedMediaItem? {
-        shManagedSession.cancel()
         isListening = false
         
         switch result {
         case .match(let match):
             if let item = match.mediaItems.first {
-//                currentItem = item
                 status = .completed
-                
                 return item
-                
-//                let route = MusicSearchResult(
-//                    title: item.title ?? "",
-//                    artist: item.artist ?? "",
-//                    artworkURL: item.artworkURL,
-//                    mediaItem: item,
-//                    showsRetryButton: true
-//                )
-                
-//                container.pathModel.append(.result(route))
-                //                navigationRoute = .result(route)
             } else {
-//                currentItem = nil
                 return nil
             }
         case .noMatch:
-//            currentItem = nil
+            print("No match found")
             return nil
         case .error(let error, _):
-//            errorDescription = error.localizedDescription
-//            currentItem = nil
+            print("Error: \(error.localizedDescription)")
             return nil
         }
     }

--- a/Headliner/Headliner/Source/Presentation/Shazam/ShazamViewModel.swift
+++ b/Headliner/Headliner/Source/Presentation/Shazam/ShazamViewModel.swift
@@ -59,18 +59,34 @@ final class ShazamViewModel: ObservableObject {
     }
     
     func start() {
-        print("ShazamVM - start()")
-        container.managers.shazamManager.isPossibleShazam()
-        let status = container.managers.shazamManager.getListeningStatus()
-        
-        switch status {
-        case true:
-            container.pathModel.paths.append(.loading)
-            let result = container.managers.shazamManager.startShazam()
-            self.result = result
-        case false:
-            print("않되")
+        guard container.managers.shazamManager.isPossibleShazam() == true else {
             return
+        }
+        
+        container.pathModel.paths.append(.loading)
+        
+        Task {
+            let result = await container.managers.shazamManager.startShazam()
+            
+            if let result = result, result.mediaItem != nil {
+                self.result = result
+                let destination = PathType.result(result)
+                container.pathModel.paths.removeLast()
+                container.pathModel.paths.append(destination)
+            } else {
+                // 노래를 찾지 못했을 경우
+                let errorResult = MusicSearchResult(
+                    title: "노래를 찾지 못했습니다",
+                    artist: "다시 시도해주세요",
+                    artworkURL: nil,
+                    mediaItem: nil,
+                    showsRetryButton: true
+                )
+                self.result = errorResult
+                let destination = PathType.result(errorResult)
+                container.pathModel.paths.removeLast()
+                container.pathModel.paths.append(destination)
+            }
         }
     }
     


### PR DESCRIPTION
Why:
- startShazam 함수가 비동기임에도 동기함수처럼 처리되어 Task 블록 내부를 기다리지 않고 종료되어 항상 nil 반환

How:
- startShazam을 async 함수로 변경하여 MusicSearchResult?를 비동기 반환
- Task 래퍼 제거 후 내부에서 await로 결과를 직접 처리
- 결과가 없을 때 showsRetryButton이 true가 되도록 로직 수정