### PR TITLE
🐛 Fix: #36 검색 UX 및 곡명/앨범 UI 문제 해결

### DIFF
--- a/Headliner/Headliner/Source/App/DIContainer.swift
+++ b/Headliner/Headliner/Source/App/DIContainer.swift
@@ -15,6 +15,8 @@ class DIContainer: ObservableObject {
     var pathModel: PathModel
     var modelContext: ModelContext?
     
+    @Published var activeTab : TabItem = .main
+    
     init(
         managers: ManagerType,
         pathModel: PathModel = PathModel()
@@ -24,7 +26,7 @@ class DIContainer: ObservableObject {
  
         self.pathModel.setObjectWillChange(objectWillChange)
     }
-    
+
     func setModelContext(_ context: ModelContext) {
         self.modelContext = context
     }

--- a/Headliner/Headliner/Source/Network/TJMediaService.swift
+++ b/Headliner/Headliner/Source/Network/TJMediaService.swift
@@ -20,6 +20,7 @@ class TJMediaService {
         let searchTerm = stripQualifiers(stripParenthetical(title))
             .trimmingCharacters(in: .whitespacesAndNewlines)
             .replacingOccurrences(of: " ", with: "")
+            .replacingOccurrences(of: #",\s*[^,]*$"#, with: "", options: .regularExpression)
 
         if searchTerm.isEmpty {
             return nil
@@ -88,7 +89,11 @@ class TJMediaService {
     }()
     
     private func normalizeTitle(_ s: String) -> String {
-        return baseNormalize(stripQualifiers(stripParenthetical(s)))
+        let normalized = stripQualifiers(stripParenthetical(s))
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .replacingOccurrences(of: #",\s*[^,]*$"#, with: "", options: .regularExpression)
+        
+        return baseNormalize(normalized)
     }
     
     private func normalizeArtist(_ s: String) -> String {

--- a/Headliner/Headliner/Source/Presentation/Home/HomeView.swift
+++ b/Headliner/Headliner/Source/Presentation/Home/HomeView.swift
@@ -4,18 +4,17 @@ struct HomeView: View {
     @Environment(\.modelContext) private var modelContext
     @EnvironmentObject var container: DIContainer
     
-    @State private var activeTab: TabItem = .main
     @State private var scrollOffset: CGFloat = 0
     @State private var isScrolled: Bool = false
     @State private var isKeyboardVisible: Bool = false
     
     private var shouldShowSearchBackground: Bool {
-        activeTab == .search
+        container.activeTab == .search
     }
     
     var body: some View {
         Group {
-            if activeTab == .main {
+            if container.activeTab == .main {
                 MainListView(
                     isScrolled: $isScrolled,
                     scrollOffset: $scrollOffset,
@@ -41,7 +40,7 @@ struct HomeView: View {
                 CustomTabBar(
                     isScrolled: $isScrolled,
                     showsSearchBar: true,
-                    activeTab: $activeTab
+                    activeTab: $container.activeTab
                 )
                 .padding(.horizontal, 25)
                 .padding(.bottom, 30)

--- a/Headliner/Headliner/Source/Presentation/Shazam/MediaItemView.swift
+++ b/Headliner/Headliner/Source/Presentation/Shazam/MediaItemView.swift
@@ -107,12 +107,11 @@ struct MediaItemView: View {
         Task {
             let song = mediaItem.toSong()
             await viewModel.addSong(song: song, context: context)
-            //            await onAddMusic(music) // 클로저 실행
-//            container.pathModel.removeAll()
-//            viewModel.goToPlaylist()
-            // TODO: addMusic
             
-            //            _ = container.managers.shazamManager.
+            withAnimation(.spring(response: 0.3, dampingFraction: 0.85)) {
+                container.pathModel.removeAll()
+                container.activeTab = .main
+            }
         }
     }
 }

--- a/Headliner/Headliner/Source/Presentation/Shazam/MediaItemView.swift
+++ b/Headliner/Headliner/Source/Presentation/Shazam/MediaItemView.swift
@@ -48,7 +48,6 @@ struct MediaItemView: View {
         .toolbar {
             ToolbarItem(placement: .navigationBarLeading) {
                 Button {
-                    print("goToBack()")
                     viewModel.goToBack()
                 } label: {
                     Image(systemName: "chevron.left")
@@ -67,12 +66,13 @@ struct MediaItemView: View {
             AsyncImage(url: url) { image in
                 image
                     .resizable()
-                    .scaledToFill()
+                    .scaledToFit()
             } placeholder: {
                 RoundedRectangle(cornerRadius: 10, style: .continuous)
                     .fill(.secondary.opacity(0.15))
             }
             .frame(width: 240, height: 240)
+            .clipShape(RoundedRectangle(cornerRadius: 10)) 
         } else {
             RoundedRectangle(cornerRadius: 10, style: .continuous)
                 .fill(.secondary.opacity(0.15))
@@ -91,7 +91,8 @@ struct MediaItemView: View {
                 .foregroundStyle(.white.opacity(0.6))
                 .multilineTextAlignment(.center)
         }
-        .padding(.bottom, 40)
+        .padding(.top, 10)
+        .padding(.bottom, 20)
     }
     
     // MARK: - Actions

--- a/Headliner/Headliner/Source/Presentation/Shazam/ShazamSearchView.swift
+++ b/Headliner/Headliner/Source/Presentation/Shazam/ShazamSearchView.swift
@@ -5,7 +5,7 @@ import MusicKit
 struct ShazamSearchView: View {
     @EnvironmentObject var container: DIContainer
     
-    @State var viewModel: ShazamViewModel
+    @StateObject var viewModel: ShazamViewModel
     @State private var scrolledID: MusicSearchResult.ID?
     
     @Binding var isScrolled: Bool
@@ -122,6 +122,7 @@ struct ShazamSearchView: View {
 
 struct SearchBarView: View {
     @Binding var text: String
+    @FocusState private var isFocused: Bool
     
     var body: some View {
         HStack {
@@ -130,11 +131,15 @@ struct SearchBarView: View {
                 text: $text,
                 prompt: Text("노래를 검색하세요").foregroundStyle(.white.opacity(0.6))
             )
+            .focused($isFocused)
             .textFieldStyle(CustomTextFieldStyle())
             .padding(.leading, 20)
             
             if !text.isEmpty {
-                Button(action: { text = "" }) {
+                Button {
+                    text = ""
+                    isFocused = true
+                } label: {
                     Image(systemName: "xmark.circle.fill")
                         .foregroundColor(.white.opacity(0.6))
                 }

--- a/Headliner/Headliner/Source/Presentation/Shazam/ShazamViewModel.swift
+++ b/Headliner/Headliner/Source/Presentation/Shazam/ShazamViewModel.swift
@@ -18,8 +18,10 @@ final class ShazamViewModel: ObservableObject {
     
     @Published var currentItem: SHMediaItem?
     @Published var result: MusicSearchResult?
+    @Published var karaokeNumberCache: [String: String] = [:]
     @Published var query: String = "" {
         didSet {
+            guard !query.isEmpty else { return }
             handleQueryChange(newQuery: query)
         }
     }
@@ -70,6 +72,9 @@ final class ShazamViewModel: ObservableObject {
             
             if let result = result, result.mediaItem != nil {
                 self.result = result
+
+                prefetchKaraokeNumber(title: result.title, artist: result.artist)
+
                 let destination = PathType.result(result)
                 container.pathModel.paths.removeLast()
                 container.pathModel.paths.append(destination)
@@ -97,6 +102,8 @@ final class ShazamViewModel: ObservableObject {
     }
     
     func handleMusicSelection(song: Song) {
+        prefetchKaraokeNumber(title: song.title, artist: song.artistName)
+
         let properties: [SHMediaItemProperty: Any] = [
             .title: song.title,
             .artist: song.artistName,
@@ -169,11 +176,13 @@ final class ShazamViewModel: ObservableObject {
             print("@Log - \(error)")
             return
         }
-        
-        let fetchedKaraokeNumber = await getKaraokeNumber(
-            title: song.title,
-            singer: song.artistName
-        )
+
+        let fetchedKaraokeNumber: String?
+        if let cached = getCachedKaraokeNumber(title: song.title, artist: song.artistName) {
+            fetchedKaraokeNumber = cached
+        } else {
+            fetchedKaraokeNumber = await getKaraokeNumber(title: song.title, singer: song.artistName)
+        }
         
         let newPlaylistSong = PlaylistMusic(
             originalSong: song,
@@ -192,6 +201,29 @@ final class ShazamViewModel: ObservableObject {
         } catch {
             print("노래방 번호 가져오기 실패: \(error.localizedDescription)")
             return nil
+        }
+    }
+
+    private func getCacheKey(title: String, artist: String) -> String {
+        return "\(title)-\(artist)"
+    }
+
+    func getCachedKaraokeNumber(title: String, artist: String) -> String? {
+        let key = getCacheKey(title: title, artist: artist)
+        return karaokeNumberCache[key]
+    }
+
+    private func prefetchKaraokeNumber(title: String, artist: String) {
+        let key = getCacheKey(title: title, artist: artist)
+
+        guard karaokeNumberCache[key] == nil else { return }
+
+        Task {
+            if let number = await getKaraokeNumber(title: title, singer: artist) {
+                await MainActor.run {
+                    karaokeNumberCache[key] = number
+                }
+            }
         }
     }
     


### PR DESCRIPTION
## ✨ What’s this PR?

### 📌 관련 이슈
- Closes #36 

---

## 🧶 주요 변경 내용 (Summary)

### 검색어 삭제 UX 개선
- 검색어 삭제 버튼 탭 시 `TextField` 내용 전체 초기화 기능 추가

### 노래 추가 시 화면 전환 플로우 개선
- `HomeView`에서 관리하던 `TabItem` 상태를 `DIContainer`로 이동
- `addSong()` 호출 시 메인 리스트 뷰로 자연스럽게 복귀되도록 수정

### Karaoke API 호출 최적화
- `MediaItemView` 진입 시 백그라운드에서 노래방 번호 API를 미리 호출
- `추가하기` 시 캐시된 번호를 활용해서 즉각 반영

###  곡명 파싱 문제 해결
- `"무제, 2014"`와 같이 쉼표(,) 뒤에 있는 텍스트도 올바르게 인식되도록 로직 수정

### 앨범 커버 UI 안정화
- 긴 비율의 앨범 커버 이미지에서도 레이아웃 깨지지 않도록 수정

---

## 💬 기타 공유 사항

- `MediaItemView` 진입 시 **백그라운드에서 노래방 번호 API를 미리 호출(prefetch)** 하도록 변경했습니닷..ㅎㅎ 
- `추가하기` 버튼을 누르면, 이미 캐시된 번호를 즉시 반환하여 **바로 반영**됩니다.  
- 캐싱 로직은 아래 세 함수 기반으로 동작합니다:
  - `getCacheKey(title:artist:)` → 곡별 캐시 키 생성
  - `getCachedKaraokeNumber(title:artist:)` → 캐시 조회
  - `prefetchKaraokeNumber(title:artist:)` → 캐시가 없을 때 API 호출 후 결과 저장