### PR TITLE
🐛 Fix. Shazam 세션 종료 시 마이크 상태 정상화

### DIFF
--- a/Headliner/Headliner/Source/Presentation/Shazam/ShazamSearchView.swift
+++ b/Headliner/Headliner/Source/Presentation/Shazam/ShazamSearchView.swift
@@ -86,15 +86,14 @@ struct ShazamSearchView: View {
     }
     
     private var shazamDefaultView: some View {
-        VStack {
-            Spacer(minLength: 10) // 최소 여백 보장
-            
+        VStack(alignment: .center, spacing: 0) {
             VStack(spacing: 24) {
                 shazamButton
                 Text("Sing Cue 하려면 탭하세요")
                     .font(.pretendardBold20)
                     .foregroundStyle(.white.opacity(0.6))
             }
+            .padding(.top, 100)
             
             Spacer()
         }

--- a/Headliner/Headliner/Source/Presentation/Shazam/ShazamViewModel.swift
+++ b/Headliner/Headliner/Source/Presentation/Shazam/ShazamViewModel.swift
@@ -102,6 +102,9 @@ final class ShazamViewModel: ObservableObject {
     }
     
     func handleMusicSelection(song: Song) {
+
+        container.managers.shazamManager.cancel()
+
         prefetchKaraokeNumber(title: song.title, artist: song.artistName)
 
         let properties: [SHMediaItemProperty: Any] = [


### PR DESCRIPTION
## ✨ What’s this PR?

### 📌 관련 이슈
- Closes #39 

---

## 🧶 주요 변경 내용 (Summary)

- **샤잠 버튼 뷰 UI 수정**
  - Spacer() 제거 후, .padding()으로 방식 변경

- **마이크 상태 관리 버그 수정**
  - `start()` 메서드 실행 후 `ShazamManager.startShazam()` 완료 시에도  
    `isListening` 상태가 true로 유지되는 문제 해결
  - Shazam 세션이 끝나도 마이크가 해제되지 않아 리소스 낭비

- **handleMusicSelection 개선**
  - 곡 선택 시 `container.managers.shazamManager.cancel()` 호출 추가
  - 세션 종료와 동시에 마이크를 명시적으로 해제하도록 수정

---

## 🧪 테스트 / 검증 내역
- Shazam 실행 → 결과 도출 후 화면 이동 → `isListening` 값이 false로 정상 전환됨 확인  
- 결과 선택 시 마이크 인디케이터가 즉시 꺼지는지 검증  
- Shazam 재시작 시 정상적으로 마이크가 다시 활성화되는지 확인  