### PR TITLE
🐛 Fix: #43 폰트 적용 문제 해결 및 토큰 plist 분리

### DIFF
--- a/Headliner/Headliner/Info.plist
+++ b/Headliner/Headliner/Info.plist
@@ -5,8 +5,10 @@
 	<key>UIAppFonts</key>
 	<array>
 		<string>Pretendard-Bold.otf</string>
-		<string>Pretendard-SemiBold.otf</string>
 		<string>Pretendard-Medium.otf</string>
+		<string>Pretendard-SemiBold.otf</string>
 	</array>
+	<key>appleMusicDeveloperToken</key>
+	<string>eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6IjlCNDlLOFA5WlQifQ.eyJpYXQiOjE3NTQ2ODcyNzcsImV4cCI6MTc3MDIzOTI3NywiaXNzIjoiVUg4TDQyNDRNQiJ9.EI-5rttxlG-U3bfoGDodUbMauYctYTIpj2iVZwtUh5cR_lNlz2qHhHmCIxcaVG-fSUg1d-G5mMa-0YlJNkN31w</string>
 </dict>
 </plist>

--- a/Headliner/Headliner/Source/Managers/MusicManager.swift
+++ b/Headliner/Headliner/Source/Managers/MusicManager.swift
@@ -17,7 +17,9 @@ final class MusicManager: MusicManagerType {
 
     private let storefront = "kr"
     private let languageHeader = "ko-KR"
-    private let developerToken: String = "eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6IjlCNDlLOFA5WlQifQ.eyJpYXQiOjE3NTQ2ODcyNzcsImV4cCI6MTc3MDIzOTI3NywiaXNzIjoiVUg4TDQyNDRNQiJ9.EI-5rttxlG-U3bfoGDodUbMauYctYTIpj2iVZwtUh5cR_lNlz2qHhHmCIxcaVG-fSUg1d-G5mMa-0YlJNkN31w"
+        private var developerToken: String {
+        return Bundle.main.object(forInfoDictionaryKey: "appleMusicDeveloperToken") as? String ?? ""
+    }
 
     func requestAuthorization() async -> MusicAuthorization.Status {
         await MusicAuthorization.request()

--- a/Headliner/Headliner/Source/Presentation/General/ShazamLoadingView.swift
+++ b/Headliner/Headliner/Source/Presentation/General/ShazamLoadingView.swift
@@ -23,12 +23,23 @@ struct ShazamLoadingView: View {
                     .onAppear {
                         loopingPlayer.player.play()
                     }
-                VStack {
+                
+                VStack(spacing: 20) {
                     Image(.shazamButton)
                         .resizable()
                         .frame(width: 220, height: 220)
-                    Spacer()
-                        .frame(height: 70)
+                    
+                    VStack(spacing: 12) {
+                        Text("검색 중")
+                            .font(.pretendardBold20)
+                            .foregroundColor(.white)
+                        
+                        Text("기기에 곡이 제대로 인식되는지 확인하세요")
+                            .font(.pretendardMedium16)
+                            .foregroundColor(.white.opacity(0.8))
+                            .multilineTextAlignment(.center)
+                    }
+                    .offset(y: 100)
                 }
             }
         }


### PR DESCRIPTION
## ✨ What’s this PR?

### 📌 관련 이슈
- Closes #43

---

## 🧶 주요 변경 내용 (Summary)
- ShazamLoadingView Figma와 UI 일치
- Info.plist에 폰트 등록 누락 수정 → 커스텀 폰트 정상 적용
- 하드코딩된 토큰을 Info.plist에 등록하여 불러오는 형식으로 변경

---

## 💬 기타 공유 사항
- `ShazamLoadingView`는 피그마 시안과 맞추기 위해 `.offset(y:)`로 위치를 강제로 조정했습니다.  
  다만, 일반적으로는 `offset` 사용을 권장하지 않는다고 알고있는데 맞나요..?

- 프로젝트 생성 시 숩이 만들어둔 Info.plist가 Target에 지정되지 않아 적용되지 않았습니다.  
  Xcode가 자동 생성한 Info.plist만 실제로 적용되고 있었기 때문에, 해당 파일에 폰트 등록을 추가하여 문제를 해결했다~ㅋㅋ 