### PR TITLE
🐛 Fix: #45 ShazamLoadingView 취소 동작 시 Task 정상 종료 처리

### DIFF
--- a/Headliner/Headliner.xcodeproj/project.pbxproj
+++ b/Headliner/Headliner.xcodeproj/project.pbxproj
@@ -12,7 +12,6 @@
 		6C7937062E461D30001083DF /* Moya in Frameworks */ = {isa = PBXBuildFile; productRef = 6C7937052E461D30001083DF /* Moya */; };
 		6C7937082E461D30001083DF /* ReactiveMoya in Frameworks */ = {isa = PBXBuildFile; productRef = 6C7937072E461D30001083DF /* ReactiveMoya */; };
 		6C79370A2E461D30001083DF /* RxMoya in Frameworks */ = {isa = PBXBuildFile; productRef = 6C7937092E461D30001083DF /* RxMoya */; };
-		BAC16E5C2E54651D00D2AB63 /* SwiftSoup in Frameworks */ = {isa = PBXBuildFile; productRef = BAC16E5B2E54651D00D2AB63 /* SwiftSoup */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -20,7 +19,7 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
-		21F6F3842E46A92900B10F99 /* Exceptions for "Headliner" folder in "Headliner" target */ = {
+		BAA42FB42E646C5200532892 /* Exceptions for "Headliner" folder in "Headliner" target */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
 				Info.plist,
@@ -33,7 +32,7 @@
 		6C7936DC2E461A1A001083DF /* Headliner */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
 			exceptions = (
-				21F6F3842E46A92900B10F99 /* Exceptions for "Headliner" folder in "Headliner" target */,
+				BAA42FB42E646C5200532892 /* Exceptions for "Headliner" folder in "Headliner" target */,
 			);
 			path = Headliner;
 			sourceTree = "<group>";
@@ -291,6 +290,7 @@
 				DEVELOPMENT_TEAM = UH8L4244MB;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = Headliner/Info.plist;
 				INFOPLIST_KEY_NSAppleMusicUsageDescription = "노래를 검색하고 보관함에 추가하기 위해 Apple Music 접근 권한이 필요합니다.";
 				INFOPLIST_KEY_NSMicrophoneUsageDescription = "노래를 검색하고 보관함에 추가하기 위해 Apple Music 접근 권한이 필요합니다.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
@@ -298,6 +298,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 18.5;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -322,6 +323,7 @@
 				DEVELOPMENT_TEAM = UH8L4244MB;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = Headliner/Info.plist;
 				INFOPLIST_KEY_NSAppleMusicUsageDescription = "노래를 검색하고 보관함에 추가하기 위해 Apple Music 접근 권한이 필요합니다.";
 				INFOPLIST_KEY_NSMicrophoneUsageDescription = "노래를 검색하고 보관함에 추가하기 위해 Apple Music 접근 권한이 필요합니다.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
@@ -329,6 +331,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 18.5;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -382,14 +385,6 @@
 				minimumVersion = 15.0.3;
 			};
 		};
-		BAC16E5A2E54651D00D2AB63 /* XCRemoteSwiftPackageReference "SwiftSoup" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/scinfu/SwiftSoup.git";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 2.10.3;
-			};
-		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -417,11 +412,6 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 6C7937022E461D30001083DF /* XCRemoteSwiftPackageReference "Moya" */;
 			productName = RxMoya;
-		};
-		BAC16E5B2E54651D00D2AB63 /* SwiftSoup */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = BAC16E5A2E54651D00D2AB63 /* XCRemoteSwiftPackageReference "SwiftSoup" */;
-			productName = SwiftSoup;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Headliner/Headliner/Source/Presentation/General/ShazamLoadingView.swift
+++ b/Headliner/Headliner/Source/Presentation/General/ShazamLoadingView.swift
@@ -10,6 +10,7 @@ import AVKit
 
 struct ShazamLoadingView: View {
     
+    @ObservedObject var viewModel: ShazamViewModel
     @StateObject private var loopingPlayer = LoopingPlayer(videoName: "background")
     
     var body: some View {
@@ -28,6 +29,7 @@ struct ShazamLoadingView: View {
                     Image(.shazamButton)
                         .resizable()
                         .frame(width: 220, height: 220)
+                        .padding(.top, 60)
                     
                     VStack(spacing: 12) {
                         Text("검색 중")
@@ -38,6 +40,13 @@ struct ShazamLoadingView: View {
                             .font(.pretendardMedium16)
                             .foregroundColor(.white.opacity(0.8))
                             .multilineTextAlignment(.center)
+                        
+                        Button {
+                            viewModel.goToBack()
+                        } label: {
+                            Text("취소하기")
+                        }
+                        .buttonStyle(RetryButtonStyle())
                     }
                     .offset(y: 100)
                 }
@@ -48,6 +57,3 @@ struct ShazamLoadingView: View {
     }
 }
 
-#Preview {
-    ShazamLoadingView()
-}

--- a/Headliner/Headliner/Source/Presentation/Shazam/ShazamSearchView.swift
+++ b/Headliner/Headliner/Source/Presentation/Shazam/ShazamSearchView.swift
@@ -28,7 +28,7 @@ struct ShazamSearchView: View {
             .navigationDestination(for: PathType.self) { type in
                 switch type {
                 case .loading:
-                    ShazamLoadingView()
+                    ShazamLoadingView(viewModel: viewModel)
                 case .result(let item):
                     if let mediaItem = item.mediaItem {
                         

--- a/Headliner/Headliner/Source/Presentation/Shazam/ShazamViewModel.swift
+++ b/Headliner/Headliner/Source/Presentation/Shazam/ShazamViewModel.swift
@@ -33,6 +33,7 @@ final class ShazamViewModel: ObservableObject {
     var errorDescription: String?
 
     private var cancellables = Set<AnyCancellable>()
+    private var shazamTask: Task<Void, Never>?
 
     init(container: DIContainer) {
         self.container = container
@@ -65,16 +66,20 @@ final class ShazamViewModel: ObservableObject {
             return
         }
         
+        // 이전 Task가 있다면 취소
+        shazamTask?.cancel()
+        
         container.pathModel.paths.append(.loading)
         
-        Task {
+        shazamTask = Task {
             let result = await container.managers.shazamManager.startShazam()
+            
+            guard !Task.isCancelled else { return }
             
             if let result = result, result.mediaItem != nil {
                 self.result = result
-
                 prefetchKaraokeNumber(title: result.title, artist: result.artist)
-
+                
                 let destination = PathType.result(result)
                 container.pathModel.paths.removeLast()
                 container.pathModel.paths.append(destination)
@@ -235,6 +240,9 @@ final class ShazamViewModel: ObservableObject {
     }
     
     func goToBack() {
+        shazamTask?.cancel()
+        container.managers.shazamManager.cancel()
         container.pathModel.pop()
     }
+    
 }


### PR DESCRIPTION
## ✨ What’s this PR?

### 📌 관련 이슈
- Closes #45  (이슈 번호 입력 필요)

---

## 🧶 주요 변경 내용 (Summary)
- ShazamLoadingView에 **취소하기 버튼** 추가
- 취소 버튼 탭 시에도 Shazam 검색 Task가 백그라운드에서 계속 실행되던 문제 해결
- Shazam 검색 Task를 프로퍼티에 저장하고, `cancel()` 호출을 통해 정상적으로 종료되도록 수정

---

## 🧪 테스트 / 검증 내역
- Shazam 로딩 화면에서 **취소 버튼 탭 시 Task가 즉시 종료**되는지 확인
- 취소 후 마이크 인디케이터가 꺼지고, 네트워크 요청이 중단되는지 확인
- 재검색 시 정상적으로 Task가 다시 시작되는지 검증