### PR TITLE
🐛 Fix. 앨범 커버 이미지 캐싱 및 로드 안정화

### DIFF
--- a/Headliner/Headliner/Source/Presentation/General/CachedImageView.swift
+++ b/Headliner/Headliner/Source/Presentation/General/CachedImageView.swift
@@ -1,0 +1,64 @@
+//
+//  CachedImageView.swift
+//  Headliner
+//
+//  Created by Henry on 9/1/25.
+//
+
+import SwiftUI
+
+struct CachedImageView: View {
+    @State private var image: UIImage?
+    @State private var isLoading = false
+    let url: URL?
+
+    var body: some View {
+        Group {
+            if let image = image {
+                Image(uiImage: image)
+                    .resizable()
+                    .scaledToFill()
+            } else if isLoading {
+                ProgressView()
+            } else {
+                Image(systemName: "music.note")
+                    .resizable()
+                    .scaledToFit()
+                    .foregroundStyle(.white.opacity(0.8))
+            }
+        }
+        .onAppear {
+            Task {
+                await loadImage()
+            }
+        }
+    }
+
+    @MainActor
+    private func loadImage() async {
+        guard let url = url else { return }
+
+        // 1. 캐시에서 먼저 확인
+        if let cachedImage = ImageCache.shared.getImage(from: url) {
+            self.image = cachedImage
+            return 
+        }
+
+        // 2. 캐시에 없으면 네트워크에서 다운로드
+        isLoading = true
+        
+        do {
+            let (data, _) = try await URLSession.shared.data(from: url)
+            guard let downloadedImage = UIImage(data: data) else {
+                isLoading = false
+                return
+            }
+            
+            ImageCache.shared.setImage(downloadedImage, for: url)
+            self.image = downloadedImage
+            isLoading = false
+        } catch {
+            isLoading = false
+        }
+    }
+}

--- a/Headliner/Headliner/Source/Presentation/Main/ImageCache.swift
+++ b/Headliner/Headliner/Source/Presentation/Main/ImageCache.swift
@@ -1,0 +1,24 @@
+//
+//  ImageCache.swift
+//  Headliner
+//
+//  Created by Henry on 9/1/25.
+//
+
+import Foundation
+import UIKit
+
+final class ImageCache {
+    static let shared = ImageCache()
+    private let cache = NSCache<NSString, UIImage>()
+
+    private init() {}
+
+    func getImage(from url: URL) -> UIImage? {
+        return cache.object(forKey: url.absoluteString as NSString)
+    }
+
+    func setImage(_ image: UIImage, for url: URL) {
+        cache.setObject(image, forKey: url.absoluteString as NSString)
+    }
+}

--- a/Headliner/Headliner/Source/Presentation/Main/MusicRowView.swift
+++ b/Headliner/Headliner/Source/Presentation/Main/MusicRowView.swift
@@ -13,29 +13,14 @@ struct MusicRowView: View {
     let artworkURL: URL?
     let previewURL: URL?
     let karaokeNumber: String?
-
+    
     var body: some View {
-        ZStack { 
+        ZStack {
             HStack(spacing: 20) {
-                AsyncImage(url: artworkURL) { phase in
-                switch phase {
-                case .success(let image):
-                    image.resizable()
-                         .scaledToFill()
-                case .failure:
-                    Image(systemName: "music.note")
-                        .resizable()
-                        .scaledToFit()
-                        .foregroundStyle(.white.opacity(0.8))
-                case .empty:
-                    ProgressView()
-                @unknown default:
-                    EmptyView()
-                }
-            }
-            .frame(width: 48, height: 48)
-            .clipShape(RoundedRectangle(cornerRadius: 8))
-            
+                CachedImageView(url: artworkURL)
+                    .frame(width: 48, height: 48)
+                    .clipShape(RoundedRectangle(cornerRadius: 8))
+                
                 VStack(spacing: 0) {
                     HStack {
                         VStack(alignment: .leading, spacing: 8) {


### PR DESCRIPTION
## ✨ What’s this PR?

### 📌 관련 이슈
- Closes #41

---

## 🧶 주요 변경 내용 (Summary)
- **ImageCache 싱글톤 구현**
  - `NSCache<NSString, UIImage>` 기반 메모리 캐시 추가
  - URL 기반으로 이미지 저장/조회 메서드(`setImage`, `getImage`) 구현

- **CachedImageView 추가**
  - `onAppear` 시 캐시 조회 → 없을 경우 네트워크 요청
  - 다운로드 완료 시 캐시에 저장 후 UI 즉시 반영
  - 로딩 중에는 `ProgressView`, 실패 시 플레이스홀더(`music.note`) 표시

- **AsyncImage 제거**
  - 불필요한 재요청 제거

---
## 💬 기타 공유 사항
- `NSCache`는 메모리 캐시라 **앱 종료 후에는 캐시가 유지되지 않음**  
- 이론상 앱 재시작이나 네트워크가 끊긴 상태에서는 이미지를 불러올 수 없어야 하는데,  
  실제 테스트에서는 **앱을 껐다 켜도 앨범 커버 이미지가 불러와짐** 🤔  
- 이유를 찾아주시면 감사하겠음.