### PR TITLE
🐛 Fix. MusicManager warmUp() 추가로 첫 MusicKit 검색 지연 해결

### DIFF
--- a/Headliner/Headliner/Source/App/HeadlinerApp.swift
+++ b/Headliner/Headliner/Source/App/HeadlinerApp.swift
@@ -11,9 +11,9 @@ import SwiftUI
 @main
 struct HeadlinerApp: App {
     @StateObject var container = DIContainer(managers: Managers())
-    
+
     let dataContainer: ModelContainer
-    
+
     init() {
         do {
             dataContainer = try ModelContainer(for: Song.self, PlaylistMusic.self)
@@ -21,12 +21,16 @@ struct HeadlinerApp: App {
             fatalError("\(error)")
         }
     }
+
     var body: some Scene {
         WindowGroup {
             HomeView()
 //                .environmentObject(PathModel())
                 .environmentObject(container)
                 .modelContainer(dataContainer)
+                .task {
+                    await container.managers.musicManager.warmUp()
+                }
         }
     }
 }

--- a/Headliner/Headliner/Source/Managers/MusicManager.swift
+++ b/Headliner/Headliner/Source/Managers/MusicManager.swift
@@ -11,16 +11,41 @@ import MusicKit
 protocol MusicManagerType {
     func requestAuthorization() async -> MusicAuthorization.Status
     func searchSongs(term: String, limit: Int) async throws -> [Song]
+    func warmUp() async
 }
 
 final class MusicManager: MusicManagerType {
-
     private let storefront = "kr"
     private let languageHeader = "ko-KR"
-        private var developerToken: String {
+    private var developerToken: String {
         return Bundle.main.object(forInfoDictionaryKey: "appleMusicDeveloperToken") as? String ?? ""
     }
 
+    func warmUp() async {
+        guard developerToken.isEmpty == false,
+              let url = URL(string: "https://api.music.apple.com/v1/test")
+        else {
+            return
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.setValue("Bearer \(developerToken)", forHTTPHeaderField: "Authorization")
+        request.setValue(languageHeader, forHTTPHeaderField: "Accept-Language")
+
+        do {
+            let (_, response) = try await URLSession.shared.data(for: request)
+            guard let http = response as? HTTPURLResponse, http.statusCode == 204 else {
+                return
+            }
+        } catch {
+            #if DEBUG
+            print("[AppleMusicAPI] warm-up failed:", error)
+            #endif
+        }
+    }
+
+    // 향후 뮤직킷 권한에서 사용 될 예정
     func requestAuthorization() async -> MusicAuthorization.Status {
         await MusicAuthorization.request()
     }
@@ -43,7 +68,7 @@ final class MusicManager: MusicManagerType {
 
         let (data, response) = try await URLSession.shared.data(for: request)
 
-        if let http = response as? HTTPURLResponse, (200...299).contains(http.statusCode) == false {
+        if let http = response as? HTTPURLResponse, (200 ... 299).contains(http.statusCode) == false {
             #if DEBUG
             if let body = String(data: data, encoding: .utf8) { print("[AppleMusicAPI] Error: \(http.statusCode)\n\(body)") }
             #endif


### PR DESCRIPTION
## ✨ What’s this PR?

### 📌 관련 이슈
- Closes #60  

---

## 🧶 주요 변경 내용 (Summary)
- MusicManager에 `warmUp()` 메서드 추가
  - 앱 시작 시 Apple Music `/v1/test` 엔드포인트를 백그라운드 호출
  - 초기 네트워크 연결 및 인증 과정을 사전에 수행하여 첫 검색 시 지연 방지
- 기존 첫 검색 시 발생하던 버벅임 문제 해결

---

## 🧪 테스트 / 검증 내역
- 앱 실행 직후 `warmUp()` 호출 시 정상적으로 204 응답 확인
- 첫 검색 시 기존 대비 빠르게 결과 반환됨 확인
<img width="260" height="130" alt="image" src="https://github.com/user-attachments/assets/ea909d83-df14-4758-9465-a72dabb18a30" />

---

## 💬 기타 공유 사항
- 속도는 저렇게 나오는데, 실제 빌드 후에는 버벅이는 느낌이.. 디버그로 빌드해서 그런가 릴리즈 해봐야 알려나