### PR TITLE
🐛 Fix: 검색 화면 키보드 dismiss 처리 및 iOS 26 탭바 중복 노출 해결

### DIFF
--- a/Headliner/Headliner/Source/Presentation/Home/HomeView.swift
+++ b/Headliner/Headliner/Source/Presentation/Home/HomeView.swift
@@ -3,11 +3,11 @@ import SwiftUI
 struct HomeView: View {
     @Environment(\.modelContext) private var modelContext
     @EnvironmentObject var container: DIContainer
-    
+
     @State private var scrollOffset: CGFloat = 0
     @State private var isScrolled: Bool = false
     @State private var isKeyboardVisible: Bool = false
-    
+
     var body: some View {
         TabView(selection: $container.activeTab) {
             MainListView(
@@ -15,13 +15,12 @@ struct HomeView: View {
                 isScrolled: $isScrolled
             )
             .tag(TabItem.main)
-            
+
             ShazamSearchView(
                 viewModel: .init(container: container),
                 isScrolled: $isScrolled
             )
             .tag(TabItem.search)
-            
         }
         .tabViewStyle(.automatic)
         .environmentObject(container)
@@ -30,14 +29,16 @@ struct HomeView: View {
         }
         .overlay(alignment: .bottom) {
             if !isKeyboardVisible && container.pathModel.paths.isEmpty {
-                CustomTabBar(
-                    isScrolled: $isScrolled,
-                    showsSearchBar: true,
-                    activeTab: $container.activeTab
-                )
-                .padding(.horizontal, 25)
-                .padding(.bottom, 30)
-                .background(.clear)
+                if #unavailable(iOS 26) {
+                    CustomTabBar(
+                        isScrolled: $isScrolled,
+                        showsSearchBar: true,
+                        activeTab: $container.activeTab
+                    )
+                    .padding(.horizontal, 25)
+                    .padding(.bottom, 30)
+                    .background(.clear)
+                }
             }
         }
         .onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardWillShowNotification)) { _ in
@@ -46,18 +47,22 @@ struct HomeView: View {
         .onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardWillHideNotification)) { _ in
             isKeyboardVisible = false
         }
+        .onTapGesture {
+            UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
+        }
     }
 }
 
 // MARK: - ScrollOffsetPreferenceKey
+
 struct ScrollOffsetPreferenceKey: PreferenceKey {
     static var defaultValue: CGFloat = 0
-    
+
     static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
         value = nextValue()
     }
 }
 
-//#Preview {
+// #Preview {
 //    HomeView()
-//}
+// }


### PR DESCRIPTION
<!--
🙏 PR 제목 컨벤션 (Gitmoji + 타입 + 이슈 번호 + 작업 요약)
-->

## ✨ What’s this PR?

### 📌 관련 이슈 (Related Issue)
- Closes #63 

---

### 🧶 주요 변경 내용 (Summary)

- 검색창 외 영역 터치 시 키보드가 내려가지 않던 문제 수정
- 포커스 상태 관리 개선
- iOS 26에서 TabBar가 중복 노출되던 문제 해결

---

### 🧪 테스트 / 검증 내역

- [x] 검색 화면에서 배경 터치 시 키보드 정상 dismiss 확인
- [x] iOS 26 시뮬레이터에서 TabBar 단일 노출 확인
- [x] 기존 iOS 버전(TabBar) 영향 없음 확인

---

### 💬 기타 공유 사항

- iOS 26 TabBar가 기본 탭바로 보이긴 하는데, 의도된 디자인이 안보여서 재확인이 필요합니다.