### PR TITLE
✨ Feat. 금영(KY) 노래방 검색 추가 및 검색 로직 개선

### DIFF
--- a/Headliner/Headliner/Source/Model/KaraokeSong.swift
+++ b/Headliner/Headliner/Source/Model/KaraokeSong.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+struct KaraokeSong: CustomStringConvertible {
+    let number: String
+    let title: String
+    let artist: String
+    
+    var description: String {
+        return "KaraokeSong(number: \"\(number)\", title: \"\(title)\", artist: \"\(artist)\")"
+    }
+}

--- a/Headliner/Headliner/Source/Model/PlaylistMusic.swift
+++ b/Headliner/Headliner/Source/Model/PlaylistMusic.swift
@@ -6,13 +6,16 @@ import SwiftData
 class PlaylistMusic: Identifiable {
     @Attribute(.unique) var id: String = UUID().uuidString
     var originalSong: Song
-    var karaokeNumber: String?
+    var tjNumber: String?
+    var kyNumber: String?
     
     init(
         originalSong: Song,
-        karaokeNumber: String? = nil
+        tjNumber: String? = nil,
+        kyNumber: String? = nil
     ) {
         self.originalSong = originalSong
-        self.karaokeNumber = karaokeNumber
+        self.tjNumber = tjNumber
+        self.kyNumber = kyNumber
     }
 }

--- a/Headliner/Headliner/Source/Network/KYMediaService.swift
+++ b/Headliner/Headliner/Source/Network/KYMediaService.swift
@@ -1,9 +1,9 @@
 import Foundation
 import SwiftSoup
 
-class TJMediaService: KaraokeServiceType {
+class KYMediaService: KaraokeServiceType {
     
-    private let baseURL = "https://www.tjmedia.com/song/accompaniment_search"
+    private let baseURL = "https://kysing.kr/search/"
     private let matcher = KaraokeMatcher.shared
     
     func fetchKaraokeNumber(title: String, artist: String) async throws -> String? {
@@ -20,12 +20,12 @@ class TJMediaService: KaraokeServiceType {
         // 네트워크 요청
         guard var components = URLComponents(string: baseURL) else { return nil }
         components.queryItems = [
-            URLQueryItem(name: "strType", value: "0"), // 통합 검색
-            URLQueryItem(name: "searchTxt", value: searchTerm)
+            URLQueryItem(name: "category", value: "2"), // 곡명 검색
+            URLQueryItem(name: "keyword", value: searchTerm)
         ]
         guard let url = components.url else { return nil }
         
-        print("[TJMediaService] Requesting single URL: \(url)")
+        print("[KYMediaService] Requesting URL: \(url)")
         
         var request = URLRequest(url: url)
         request.setValue("Mozilla/5.0", forHTTPHeaderField: "User-Agent")
@@ -43,15 +43,15 @@ class TJMediaService: KaraokeServiceType {
     
     private func parseHTML(html: String) throws -> [KaraokeSong] {
         let doc: Document = try SwiftSoup.parse(html)
-        let rows = try doc.select("div.music-search-list ul.chart-list-area > li")
+        let rows = try doc.select("ul.search_chart_list")
         
         var songs: [KaraokeSong] = []
         for row in rows {
-            let number = try row.select("span.num2").text()
+            let number = try row.select("li.search_chart_num").text()
             if number.isEmpty { continue }
             
-            let title = try row.select("li.title3 span, li.title2 span, li.title span").first()?.text() ?? ""
-            let artist = try row.select("li.singer span, li.singer2 span").first()?.text() ?? ""
+            let title = try row.select("li.search_chart_tit span.tit").first()?.text() ?? ""
+            let artist = try row.select("li.search_chart_tit span.mo-art").text()
             
             if !title.isEmpty {
                 songs.append(KaraokeSong(number: number, title: title, artist: artist))

--- a/Headliner/Headliner/Source/Network/KaraokeServiceType.swift
+++ b/Headliner/Headliner/Source/Network/KaraokeServiceType.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+protocol KaraokeServiceType {
+    func fetchKaraokeNumber(title: String, artist: String) async throws -> String?
+}

--- a/Headliner/Headliner/Source/Presentation/Main/MainListView.swift
+++ b/Headliner/Headliner/Source/Presentation/Main/MainListView.swift
@@ -80,6 +80,7 @@ struct MainListView: View {
         let items = KaraokeType.allCases
         let width: CGFloat = 60
         let height: CGFloat = 36
+        let padding: CGFloat = 4
         
         return ZStack(alignment: .leading) {
             Capsule()

--- a/Headliner/Headliner/Source/Presentation/Main/MainListView.swift
+++ b/Headliner/Headliner/Source/Presentation/Main/MainListView.swift
@@ -5,11 +5,15 @@
 //  Created by Henry on 8/9/25.
 //
 
-import SwiftUI
 import SwiftData
+import SwiftUI
+
+enum KaraokeType: String, CaseIterable {
+    case tj = "TJ"
+    case ky = "KY"
+}
 
 struct MainListView: View {
-    
     @Query(sort: \PlaylistMusic.originalSong.title) private var playlists: [PlaylistMusic]
     
     var viewModel: PlaylistViewModel
@@ -17,8 +21,18 @@ struct MainListView: View {
     
     @Binding var isScrolled: Bool
     @State private var previousScrollOffset: CGFloat = 0
+    @State private var selectedType: KaraokeType = .tj
     
     private let scrollThreshold: CGFloat = 20
+    
+    // 선택된 타입에 따라 표시할 노래번호를 결정
+    private func getKaraokeNumber(for playlist: PlaylistMusic) -> String {
+        if selectedType == .tj {
+            return playlist.tjNumber ?? ""
+        } else {
+            return playlist.kyNumber ?? ""
+        }
+    }
     
     var body: some View {
         ZStack {
@@ -40,22 +54,65 @@ struct MainListView: View {
     var musicListView: some View {
         ZStack {
             VStack(alignment: .leading, spacing: 0) {
-                titleView
+                titleHeaderView
                 scrollView
             }
             bottomDeemedlayer
         }
     }
     
-    var titleView: some View {
-        Text(viewTitle)
-            .font(.pretendardBold20)
-            .foregroundStyle(.white)
-            .padding(.top, 40)
-            .padding(.horizontal, 25)
-            .padding(.bottom, 20)
+    var titleHeaderView: some View {
+        HStack(alignment: .center) {
+            Text(viewTitle)
+                .font(.pretendardBold20)
+                .foregroundStyle(.white)
+            
+            Spacer()
+            
+            segmentPicker
+        }
+        .padding(.top, 40)
+        .padding(.horizontal, 25)
+        .padding(.bottom, 20)
     }
     
+    var segmentPicker: some View {
+        let items = KaraokeType.allCases
+        let width: CGFloat = 60
+        let height: CGFloat = 36
+        
+        return ZStack(alignment: .leading) {
+            Capsule()
+                .fill(Color.white.opacity(0.1))
+                .frame(
+                    width: width * CGFloat(items.count) + padding * 2,
+                    height: height + padding * 2
+                )
+            
+            Capsule()
+                .fill(Color.white)
+                .frame(width: width, height: height)
+                .offset(
+                    x: CGFloat(items.firstIndex(of: selectedType) ?? 0) * width + padding
+                )
+                .animation(.easeInOut(duration: 0.2), value: selectedType)
+            
+            HStack(spacing: 0) {
+                ForEach(items, id: \.self) { type in
+                    Button {
+                        selectedType = type
+                    } label: {
+                        Text(type.rawValue)
+                            .font(.pretendardSemiBold16)
+                            .foregroundStyle(selectedType == type ? .black : .white)
+                            .frame(width: width, height: height)
+                    }
+                }
+            }
+            .padding(4)
+        }
+    }
+  
     var scrollView: some View {
         ScrollView {
             LazyVStack(spacing: 0) {
@@ -66,29 +123,27 @@ struct MainListView: View {
                                  artistName: t.originalSong.artistName,
                                  artworkURL: t.originalSong.artworkURL,
                                  previewURL: t.originalSong.previewURL,
-                                 karaokeNumber: t.karaokeNumber)
-                    .swipeActions(edge: .trailing) {
-                        Button {
-                            viewModel.deleteItems(
-                                at: IndexSet(integer: index),
-                                from: playlists
-                            )
-                        } label: {
-                            Image(.delete)
-                                .offset(x: 3)
-                            
+                                 karaokeNumber: getKaraokeNumber(for: t))
+                        .swipeActions(edge: .trailing) {
+                            Button {
+                                viewModel.deleteItems(
+                                    at: IndexSet(integer: index),
+                                    from: playlists
+                                )
+                            } label: {
+                                Image(.delete)
+                                    .offset(x: 3)
+                            }
+                            .tint(.clear)
                         }
-                        .tint(.clear)
-                        
-                    }
-                    .enableScrollViewSwipeActions()
+                        .enableScrollViewSwipeActions()
                 }
             }
             .scrollTargetLayout()
         }
         .onScrollGeometryChange(for: CGFloat.self) { geometry in
             geometry.contentOffset.y
-        } action: { oldValue, newValue in
+        } action: { _, newValue in
             let delta = newValue - previousScrollOffset
             
             if delta > scrollThreshold {

--- a/Headliner/Headliner/Source/Presentation/Shazam/ShazamViewModel.swift
+++ b/Headliner/Headliner/Source/Presentation/Shazam/ShazamViewModel.swift
@@ -207,26 +207,24 @@ final class ShazamViewModel: ObservableObject {
             return
         }
 
-        // 1. TJ 번호 우선 가져오기
-        let tjNumber = await fetchTJNumber(title: song.title, artist: song.artistName)
+        // 1. 캐시를 활용하여 TJ/KY 번호 가져오기
+        let karaokeNumbers = await fetchKaraokeNumbers(title: song.title, artist: song.artistName)
         
-        // 2. 즉시 저장 (KY는 nil)
+        // 2. 즉시 저장 (TJ는 바로 설정, KY는 백그라운드에서 업데이트)
         let newPlaylistSong = PlaylistMusic(
             originalSong: song,
-            tjNumber: tjNumber ?? "없음",
+            tjNumber: karaokeNumbers.tj,
             kyNumber: nil
         )
         
         context.insert(newPlaylistSong)
-        print("Playlist에 추가됨: \(song.title) - TJ: \(tjNumber ?? "없음"), KY: Fetching...")
+        print("Playlist에 추가됨: \(song.title) - TJ: \(karaokeNumbers.tj), KY: Fetching...")
         
-        // 3. KY 번호 백그라운드로 가져오기
+        // 3. KY 번호 백그라운드로 업데이트 (이미 가져온 값 사용)
         Task {
-            let kyNumber = await fetchKYNumber(title: song.title, artist: song.artistName)
-            
             await MainActor.run {
-                newPlaylistSong.kyNumber = kyNumber ?? "없음"
-                print("KY Update 완료: \(song.title) - \(kyNumber ?? "없음")")
+                newPlaylistSong.kyNumber = karaokeNumbers.ky
+                print("KY Update 완료: \(song.title) - \(karaokeNumbers.ky)")
             }
         }
     }

--- a/Headliner/Headliner/Source/Presentation/Shazam/ShazamViewModel.swift
+++ b/Headliner/Headliner/Source/Presentation/Shazam/ShazamViewModel.swift
@@ -11,6 +11,11 @@ import MusicKit
 import ShazamKit
 import SwiftData
 
+struct KaraokeNumbers {
+    let tj: String
+    let ky: String
+}
+
 @MainActor
 final class ShazamViewModel: ObservableObject {
     @Published var currentItem: SHMediaItem?
@@ -23,16 +28,19 @@ final class ShazamViewModel: ObservableObject {
         }
     }
     
-    @Published var karaokeNumberCache: [String: String] = [:]
     @Published var results: [Song] = []
     
     var container: DIContainer
-    var tjMediaService = TJMediaService() /// 곡번호
+    var tjMediaService = TJMediaService()
+    var kyMediaService = KYMediaService()
     var destination: PathType?
     var errorDescription: String?
     
     private var cancellables = Set<AnyCancellable>()
     private var shazamTask: Task<Void, Never>?
+    
+    // 캐시: [title-artist: KaraokeNumbers]
+    private var karaokeCache: [String: KaraokeNumbers] = [:]
     
     init(container: DIContainer) {
         self.container = container
@@ -41,7 +49,6 @@ final class ShazamViewModel: ObservableObject {
     func requestAuthorization() async -> MusicAuthorization.Status {
         let result = await container.managers.musicManager.requestAuthorization()
         
-        // TODO: 권한에 따른 화면 처리
         switch result {
         case .notDetermined:
             print("not determined")
@@ -83,12 +90,10 @@ final class ShazamViewModel: ObservableObject {
     }
     
     func executeShazam() async {
-        
         guard container.managers.shazamManager.isPossibleShazam() == true else {
             return
         }
         
-        // 이전 Task가 있다면 취소
         shazamTask?.cancel()
         
         container.pathModel.paths.append(.loading)
@@ -101,13 +106,12 @@ final class ShazamViewModel: ObservableObject {
             
             if let result = result, result.mediaItem != nil {
                 self.result = result
-                prefetchKaraokeNumber(title: result.title, artist: result.artist)
+                prefetchKaraokeNumbers(title: result.title, artist: result.artist)
                 
                 let destination = PathType.result(result)
                 container.pathModel.pop()
                 container.pathModel.append(destination)
             } else {
-                // 노래를 찾지 못했을 경우
                 let errorResult = MusicSearchResult(
                     status: .failure,
                     title: "결과 없음",
@@ -131,7 +135,7 @@ final class ShazamViewModel: ObservableObject {
     func handleMusicSelection(song: Song) {
         container.managers.shazamManager.cancel()
         
-        prefetchKaraokeNumber(title: song.title, artist: song.artistName)
+        prefetchKaraokeNumbers(title: song.title, artist: song.artistName)
         
         let properties: [SHMediaItemProperty: Any] = [
             .title: song.title,
@@ -154,17 +158,15 @@ final class ShazamViewModel: ObservableObject {
     private var searchTask: Task<Void, Error>?
     
     private func handleQueryChange(newQuery: String) {
-        // 이전 검색 취소
         searchTask?.cancel()
         
-        // 새로운 검색 예약
         searchTask = Task {
             try await Task.sleep(for: .milliseconds(500))
             
             if newQuery.count >= 2 {
                 await search(with: newQuery)
             } else {
-                results = [] // 검색어가 짧으면 결과 초기화
+                results = []
             }
         }
     }
@@ -204,56 +206,86 @@ final class ShazamViewModel: ObservableObject {
             print("@Log - \(error)")
             return
         }
+
+        // 1. TJ 번호 우선 가져오기
+        let tjNumber = await fetchTJNumber(title: song.title, artist: song.artistName)
         
-        let fetchedKaraokeNumber: String?
-        if let cached = getCachedKaraokeNumber(title: song.title, artist: song.artistName) {
-            fetchedKaraokeNumber = cached
-        } else {
-            fetchedKaraokeNumber = await getKaraokeNumber(title: song.title, singer: song.artistName)
-        }
-        
+        // 2. 즉시 저장 (KY는 nil)
         let newPlaylistSong = PlaylistMusic(
             originalSong: song,
-            karaokeNumber: fetchedKaraokeNumber ?? "없음"
+            tjNumber: tjNumber ?? "없음",
+            kyNumber: nil
         )
         
         context.insert(newPlaylistSong)
+        print("Playlist에 추가됨: \(song.title) - TJ: \(tjNumber ?? "없음"), KY: Fetching...")
         
-        print("Playlist에 추가됨: \(newPlaylistSong.originalSong.title) - 노래방 번호: \(newPlaylistSong.karaokeNumber ?? "없음")")
+        // 3. KY 번호 백그라운드로 가져오기
+        Task {
+            let kyNumber = await fetchKYNumber(title: song.title, artist: song.artistName)
+            
+            await MainActor.run {
+                newPlaylistSong.kyNumber = kyNumber ?? "없음"
+                print("KY Update 완료: \(song.title) - \(kyNumber ?? "없음")")
+            }
+        }
     }
     
-    @MainActor
-    func getKaraokeNumber(title: String, singer: String) async -> String? {
+    
+    private func getCacheKey(title: String, artist: String) -> String {
+        "\(title)-\(artist)"
+    }
+    
+    /// 캐시 확인 후, 없으면 TJ/KY 병렬로 fetch
+    private func fetchKaraokeNumbers(title: String, artist: String) async -> KaraokeNumbers {
+        let key = getCacheKey(title: title, artist: artist)
+        
+        // 캐시에 있으면 바로 리턴
+        if let cached = karaokeCache[key] {
+            return cached
+        }
+        
+        // 병렬로 fetch
+        async let tj = fetchTJNumber(title: title, artist: artist)
+        async let ky = fetchKYNumber(title: title, artist: artist)
+        
+        let numbers = KaraokeNumbers(
+            tj: await tj ?? "없음",
+            ky: await ky ?? "없음"
+        )
+        
+        // 캐시 저장
+        karaokeCache[key] = numbers
+        
+        return numbers
+    }
+    
+    private func fetchTJNumber(title: String, artist: String) async -> String? {
         do {
-            return try await tjMediaService.fetchKaraokeNumber(title: title, artist: singer)
+            return try await tjMediaService.fetchKaraokeNumber(title: title, artist: artist)
         } catch {
-            print("노래방 번호 가져오기 실패: \(error.localizedDescription)")
+            print("TJ 번호 가져오기 실패: \(error.localizedDescription)")
             return nil
         }
     }
     
-    private func getCacheKey(title: String, artist: String) -> String {
-        return "\(title)-\(artist)"
-    }
-    
-    func getCachedKaraokeNumber(title: String, artist: String) -> String? {
-        let key = getCacheKey(title: title, artist: artist)
-        return karaokeNumberCache[key]
-    }
-    
-    private func prefetchKaraokeNumber(title: String, artist: String) {
-        let key = getCacheKey(title: title, artist: artist)
-        
-        guard karaokeNumberCache[key] == nil else { return }
-        
-        Task {
-            if let number = await getKaraokeNumber(title: title, singer: artist) {
-                await MainActor.run {
-                    karaokeNumberCache[key] = number
-                }
-            }
+    private func fetchKYNumber(title: String, artist: String) async -> String? {
+        do {
+            return try await kyMediaService.fetchKaraokeNumber(title: title, artist: artist)
+        } catch {
+            print("KY 번호 가져오기 실패: \(error.localizedDescription)")
+            return nil
         }
     }
+    
+    /// 미리 가져오기 (백그라운드에서 비동기로)
+    private func prefetchKaraokeNumbers(title: String, artist: String) {
+        Task {
+            await fetchKaraokeNumbers(title: title, artist: artist)
+        }
+    }
+    
+    // MARK: - Navigation
     
     func goToPlaylist() {
         container.pathModel.removeAll()

--- a/Headliner/Headliner/Source/Utilities/KaraokeMatcher.swift
+++ b/Headliner/Headliner/Source/Utilities/KaraokeMatcher.swift
@@ -1,0 +1,128 @@
+import Foundation
+
+final class KaraokeMatcher {
+    
+    static let shared = KaraokeMatcher()
+    
+    private init() {}
+    
+    func findBestMatch(songs: [KaraokeSong], originalTitle: String, originalArtist: String) -> KaraokeSong? {
+        let nt = normalizeTitle(originalTitle)
+        let na = normalizeArtist(originalArtist)
+        
+        let exactTitleMatches = songs.filter { normalizeTitle($0.title) == nt }
+        if !exactTitleMatches.isEmpty {
+            if let aliasHit = exactTitleMatches.first(where: { areArtistsEquivalent($0.artist, originalArtist) }) {
+                return aliasHit
+            }
+            return exactTitleMatches.max {
+                similarity(normalizeArtist($0.artist), na) < similarity(normalizeArtist($1.artist), na)
+            }
+        }
+        
+        struct Scored { let song: KaraokeSong; let score: Double }
+        var scored: [Scored] = []
+        
+        for s in songs {
+            let st = normalizeTitle(s.title)
+            let sa = normalizeArtist(s.artist)
+            
+            let titleScore = similarity(st, nt)
+            if titleScore < 0.65 { continue }
+            
+            let isAlias = areArtistsEquivalent(sa, na)
+            let artistScore: Double = isAlias ? 1.0 : similarity(sa, na)
+            let bonus = isAlias ? 0.08 : 0.0
+            
+            let finalScore = 0.75 * titleScore + 0.25 * artistScore + bonus
+            scored.append(Scored(song: s, score: finalScore))
+        }
+        
+        return scored.max(by: { $0.score < $1.score })?.song
+    }
+    
+    func stripQualifiers(_ s: String) -> String {
+        let pattern = #"(?i)\s*-\s*(live|remaster(ed)?|acoustic|inst(rumental)?|mr|ver\.?|version|original|clean|explicit|edit|mix|ost).*$"#
+        return s.replacingOccurrences(of: pattern, with: "", options: .regularExpression)
+    }
+    
+    func stripParenthetical(_ s: String) -> String {
+        return s.replacingOccurrences(of: #"\s*[\(\[\{][^\)\]\}]*[\)\]\}]"#, with: "", options: .regularExpression)
+    }
+    
+    // MARK: - Private Helpers
+    
+    private lazy var artistCanonicals: [String: String] = {
+        let aliases: [String: [String]] = [
+            "아이유": ["IU"], "방탄소년단": ["BTS"], "소녀시대": ["Girls' Generation", "SNSD"],
+            "세븐틴": ["SEVENTEEN", "SVT"], "르세라핌": ["LE SSERAFIM", "LESSERAFIM"],
+            "뉴진스": ["NewJeans", "New Jeans"], "에스파": ["aespa"], "스트레이 키즈": ["Stray Kids", "SKZ"]
+        ]
+        var map: [String: String] = [:]
+        for (canonicalName, aliasList) in aliases {
+            let normalizedCanonical = normalizeArtist(canonicalName)
+            let allNames = [canonicalName] + aliasList
+            for name in allNames {
+                map[normalizeArtist(name)] = normalizedCanonical
+            }
+        }
+        return map
+    }()
+    
+    private func normalizeTitle(_ s: String) -> String {
+        let normalized = stripQualifiers(stripParenthetical(s))
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .replacingOccurrences(of: #",\s*[^,]*$"#, with: "", options: .regularExpression)
+        
+        return baseNormalize(normalized)
+    }
+    
+    private func normalizeArtist(_ s: String) -> String {
+        return baseNormalize(stripParenthetical(s))
+    }
+    
+    private func baseNormalize(_ s: String) -> String {
+        var r = s.folding(options: [.caseInsensitive, .diacriticInsensitive, .widthInsensitive], locale: .current)
+        if let idx = r.firstIndex(where: { [":", "–", "—", "-", "—"].contains(String($0)) }) {
+            let left = r[..<idx]
+            if left.count >= 4 { r = String(left) }
+        }
+        r = r.replacingOccurrences(of: #"[\p{P}\p{S}]"#, with: "", options: .regularExpression)
+        r = r.replacingOccurrences(of: #"\s+"#, with: "", options: .regularExpression)
+        return r.lowercased()
+    }
+    
+    private func levenshtein(_ a: String, _ b: String) -> Int {
+        let aChars = Array(a), bChars = Array(b)
+        if aChars.isEmpty { return bChars.count }
+        if bChars.isEmpty { return aChars.count }
+        var dist = Array(repeating: Array(repeating: 0, count: bChars.count + 1), count: aChars.count + 1)
+        for i in 0...aChars.count { dist[i][0] = i }
+        for j in 0...bChars.count { dist[0][j] = j }
+        for i in 1...aChars.count {
+            for j in 1...bChars.count {
+                let cost = (aChars[i-1] == bChars[j-1]) ? 0 : 1
+                dist[i][j] = min(dist[i-1][j] + 1, dist[i][j-1] + 1, dist[i-1][j-1] + cost)
+            }
+        }
+        return dist[aChars.count][bChars.count]
+    }
+    
+    private func similarity(_ a: String, _ b: String) -> Double {
+        if a.isEmpty && b.isEmpty { return 1.0 }
+        let d = Double(levenshtein(a, b))
+        let m = Double(max(a.count, b.count))
+        return max(0.0, 1.0 - d / m)
+    }
+    
+    private func areArtistsEquivalent(_ a: String, _ b: String) -> Bool {
+        let na = normalizeArtist(a)
+        let nb = normalizeArtist(b)
+        if na == nb { return true }
+        
+        let canonicalA = artistCanonicals[na] ?? na
+        let canonicalB = artistCanonicals[nb] ?? nb
+        
+        return canonicalA == canonicalB
+    }
+}


### PR DESCRIPTION
## 📌 변경 개요
TJ 노래방 검색에 더해 금영(KY) 노래방 검색을 지원 및
TJ <-> KY로 바꿀 수 있는 커스텀 세그먼트 피커 추가

---

## ✨ 주요 변경 사항

### 1. 금영(KY) 노래방 검색 서비스 추가
- `KYMediaService` 추가
- kysing.kr 크롤링 기반 노래 번호 검색 구현
- TJ / KY 결과를 공통으로 다루기 위한 `KaraokeSong` 모델 정의

### 2. 노래방 검색 로직 리팩토링
- 문자열 정규화 및 유사도 계산 로직을 `KaraokeMatcher`로 분리
- `KaraokeServiceType` 프로토콜 도입
- `TJMediaService` 리팩토링 및 공통 로직 위임

### 3. 뷰모델 및 데이터 모델 개선
- `PlaylistMusic` 모델에서 노래방 번호를
  `tjNumber`, `kyNumber`로 분리
- `ShazamViewModel`에서
  - `async let` 기반 TJ/KY 병렬 검색
  - 검색 결과 캐싱으로 중복 요청 방지

### 4. UI 업데이트
- `MainListView` 상단에 TJ / KY 커스텀 세그먼트 추가
- 선택된 노래방 타입에 따라 리스트에 표시되는 번호 변경

### 5. 성능 개선 (KY 지연 대응)
- KY 검색 속도 이슈로 인해
  - TJ 번호를 우선 저장
  - KY 번호는 백그라운드에서 비동기 업데이트하도록 변경

---

## 🧪 테스트 포인트
- TJ / KY 각각 검색 정상 동작 여부
- KY 번호가 늦게 업데이트되는 경우 UI 반영 여부
- 세그먼트 전환 시 번호 표시 정상 여부
- 동일 곡 재검색 시 캐시 적용 여부

---

## ⚠️ 참고 사항
- KY 사이트 응답 속도가 느려 TJ 우선 전략을 사용했습니다 -> Discord에서 남겨놓았던거 내용